### PR TITLE
Wrap send calls to WebSocket in try/catch block

### DIFF
--- a/luxtronik2-ws.js
+++ b/luxtronik2-ws.js
@@ -35,8 +35,13 @@ module.exports = function(RED) {
 
         node.ws.on('open', function open() {
             node.status({fill:"green",shape:"dot",text:"connected"});
-            node.ws.send(login);
-            node.ws.send("REFRESH");
+
+            try {
+                node.ws.send(login);
+                node.ws.send("REFRESH");
+            } catch (e) {
+                ws.close();
+            }
         });
         
         node.ws.on('message', function (data, flags) {


### PR DESCRIPTION
I've been experimenting with Node-RED and your Luxtronik node running in an docker container on my Mac. The next day in the morning the container has died for the second time now. I assume it's due to the sleep mode of my Mac, the corresponding log entry was:

```
8 Aug 23:27:18 - [red] Uncaught Exception:
8 Aug 23:27:18 - Error: WebSocket is not open: readyState 0 (CONNECTING)
    at WebSocket.send (/data/node_modules/ws/lib/websocket.js:327:13)
    at WebSocket.open (/data/node_modules/node-red-contrib-luxtronik2-ws/luxtronik2-ws.js:38:21)
    at emitNone (events.js:106:13)
    at WebSocket.emit (events.js:208:7)
    at WebSocket.setSocket (/data/node_modules/ws/lib/websocket.js:172:10)
    at ClientRequest.req.on (/data/node_modules/ws/lib/websocket.js:646:15)
    at emitThree (events.js:136:13)
    at ClientRequest.emit (events.js:217:7)
    at Socket.socketOnData (_http_client.js:489:11)
    at emitOne (events.js:116:13)
```